### PR TITLE
Start execute script from a label #68

### DIFF
--- a/Test/TestParser/TestStartFromLabel/TestStartFromLabel.gd
+++ b/Test/TestParser/TestStartFromLabel/TestStartFromLabel.gd
@@ -1,0 +1,18 @@
+extends GutTest
+
+const file_path = "res://Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk"
+
+var say_char:Dictionary
+var say_text:String
+func _on_say(character:Dictionary, text:String):
+	say_char = character
+	say_text = text
+
+func test_start_from_label():
+	Rakugo.connect("say", self, "_on_say")
+	
+	Rakugo.parse_and_execute_script(file_path, "pictures")
+	
+	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	
+	assert_eq(say_text, "Pictures of places that I have visited.")

--- a/Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk
+++ b/Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk
@@ -1,0 +1,5 @@
+door:
+"Where did I put the key?"
+
+pictures:
+"Pictures of places that I have visited."

--- a/Test/TestParser/TestStartFromLabel/TestStartFromLabel.tscn
+++ b/Test/TestParser/TestStartFromLabel/TestStartFromLabel.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Test/TestParser/TestStartFromLabel/TestStartFromLabel.gd" type="Script" id=1]
+
+[node name="TestStartFromLabel" type="Node"]
+script = ExtResource( 1 )

--- a/addons/Rakugo/Rakugo.gd
+++ b/addons/Rakugo/Rakugo.gd
@@ -179,11 +179,11 @@ func reset_game():
 func parse_script(file_name:String) -> int:
 	return current_parser.parse_script(file_name)
 	
-func execute_script(file_base_name:String) -> int:
-	return current_parser.execute_script(file_base_name)
+func execute_script(script_name:String, label_name:String = "") -> int:
+	return current_parser.execute_script(script_name, label_name)
 	
-func parse_and_execute_script(file_name) -> int:
-	return current_parser.parse_and_execute(file_name)
+func parse_and_execute_script(file_name:String, label_name:String = "") -> int:
+	return current_parser.parse_and_execute(file_name, label_name)
 
 func send_execute_script_finished(file_base_name:String):
 	emit_signal("execute_script_finished", file_base_name)

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -341,6 +341,9 @@ func do_execute_script(parameters:Dictionary) -> int:
 	
 	if parameters.has("label_name"):
 		index = do_execute_jump(parameters["label_name"], parse_array, labels)
+		
+		if index == -1:
+			return FAILED
 	
 	while !parameters["stop"] and index < parse_array.size():
 		var line:Array = parse_array[index]


### PR DESCRIPTION
Fix #68 

Now we can start execution of a script from a label.

2 Rakugo methods are updated to handle this case:
func execute_script(script_name:String, label_name:String = "") -> int:
func parse_and_execute_script(file_name:String, label_name:String = "") -> int:

Add 1 test:
TestStartFromLabel