### PR TITLE
RakuScript, add keyword exit #133

### DIFF
--- a/Test/TestParser/TestExit/TestExit.gd
+++ b/Test/TestParser/TestExit/TestExit.gd
@@ -1,0 +1,18 @@
+extends GutTest
+
+const file_path = "res://Test/TestParser/TestExit/TestExit.rk"
+
+var script_name := ""
+func _on_execute_script_finished(file_base_name:String):
+	script_name = file_base_name
+
+func test_exit():
+	Rakugo.connect("execute_script_finished", self, "_on_execute_script_finished")
+	
+	Rakugo.parse_and_execute_script(file_path)
+	
+	Rakugo.do_step()
+	
+	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
+
+	assert_eq(script_name, "TestExit")

--- a/Test/TestParser/TestExit/TestExit.rk
+++ b/Test/TestParser/TestExit/TestExit.rk
@@ -1,0 +1,3 @@
+"Where did I put the key?"
+exit
+"Pictures of places that I have visited."

--- a/Test/TestParser/TestExit/TestExit.tscn
+++ b/Test/TestParser/TestExit/TestExit.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Test/TestParser/TestExit/TestExit.gd" type="Script" id=1]
+
+[node name="TestExit" type="Node"]
+script = ExtResource( 1 )

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -65,6 +65,8 @@ var parser_regex :={
 	JUMP = "^jump (?<label>{NAME})( if (?<expression>.+))?$",
 	# for setting Rakugo variables
 	SET_VARIABLE = "(?<lvar_name>{VARIABLE}) = ((?<text>{STRING})|(?<number>{NUMERIC})|(?<rvar_name>{VARIABLE}))",
+	# exit dialogue
+	EXIT = "^exit$",
 	# $ some_gd_script_code
 #	IN_LINE_GDSCRIPT = "^\\$.*",
 	# gdscript:
@@ -342,6 +344,8 @@ func do_execute_script(parameters:Dictionary) -> int:
 		var result = line[1]
 		
 		match(line[0]):
+			"EXIT":
+				break
 			"JUMP":
 				var can_jump = false
 


### PR DESCRIPTION
Fix #133 

Now we can Exit/Quit a dialogue when we want.

By example, instead of do
```gd
door:
  "The door is locked."
  "Where did I put the key?"
  jump end

draw:
  "Pictures of places that I have visited."
  "I used to do a lot of traveling."
  jump end

end:
```

Now we can do
```
door:
  "The door is locked."
  "Where did I put the key?"
  exit

draw:
  "Pictures of places that I have visited."
  "I used to do a lot of traveling."
  exit
```