### PR TITLE
update plugin.cfg

### DIFF
--- a/addons/Rakugo/plugin.cfg
+++ b/addons/Rakugo/plugin.cfg
@@ -1,7 +1,7 @@
 [plugin]
 
-name="Rakugo"
-description="Rakugo is framework for story driven games"
+name="Rakugo Core"
+description="Rakugo Core is base for frameworks for story driven games"
 author="Rakugo Team"
-version="3.3"
+version="1.1"
 script="plugin.gd"


### PR DESCRIPTION
Changed name to *"Rakugo Core"*.
Number version was confusing as it was `3.3` instead of `1.0`, it soon will be `1.1` so I set it to that.
Also description I changed to *"Rakugo Core is base for frameworks for story driven games"* - I think it is more proper.