### PR TITLE
Fix #174 and #166 : Add RakugoTest class and update all parser tests

### DIFF
--- a/Test/RakugoTest.gd
+++ b/Test/RakugoTest.gd
@@ -1,0 +1,73 @@
+extends GutTest
+
+func get_file_base_name(file_path:String) -> String:
+	return file_path.get_file().get_basename()
+
+func watch_rakugo_signals():
+	watch_signals(Rakugo)
+
+func wait_signal(signal_name:String, parameters:Array):
+	yield(yield_to(Rakugo, signal_name, 0.2), YIELD)
+
+	assert_signal_emitted_with_parameters(
+		Rakugo,
+		signal_name,
+		parameters)
+
+func wait_execute_script_start(file_base_name:String):
+	return wait_signal("execute_script_start", [file_base_name])
+
+func wait_parse_and_execute_script(file_path:String):
+	Rakugo.parse_and_execute_script(file_path)
+	
+	return wait_execute_script_start(get_file_base_name(file_path))
+
+func wait_ask(character:Dictionary, text:String, default_answer:String):
+	return wait_signal("ask", [character, text, default_answer])
+
+func assert_ask_return(var_name:String, value):
+	assert_true(Rakugo.is_waiting_ask_return())
+
+	Rakugo.ask_return(value)
+	
+	assert_eq(value, Rakugo.get_variable(var_name))
+
+func wait_execute_script_finished(file_base_name:String):
+	return wait_signal("execute_script_finished", [file_base_name])
+
+func assert_character_name_eq(char_tag:String, value:String):
+	var character = Rakugo.get_character(char_tag)
+
+	assert_eq(character.get("name"), value)
+
+func assert_do_step():
+	assert_true(Rakugo.is_waiting_step())
+	
+	Rakugo.do_step()
+
+func wait_say(character:Dictionary, text:String):
+	return wait_signal("say", [character, text])
+
+func assert_variable(var_name:String, var_type, value):
+	var var_ = Rakugo.get_variable(var_name)
+
+	assert_eq(typeof(var_), var_type)
+	assert_eq(var_, value)
+
+func wait_character_variable_changed(char_tag:String, var_name:String, var_type, value):
+	yield(wait_signal("character_variable_changed", [char_tag, var_name, value]), "completed")
+
+	assert_variable(var_name, var_type, value)
+
+func wait_variable_changed(var_name:String, var_type, value):
+	yield(wait_signal("variable_changed", [var_name, value]), "completed")
+
+	assert_variable(var_name, var_type, value)
+
+func wait_menu(choices:PoolStringArray):
+	return wait_signal("menu", [choices])
+
+func assert_menu_return(index:int):
+	assert_true(Rakugo.is_waiting_menu_return())
+
+	Rakugo.menu_return(index)

--- a/Test/TestParser/TestAsk/TestAsk.gd
+++ b/Test/TestParser/TestAsk/TestAsk.gd
@@ -1,28 +1,16 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://test/TestParser/TestAsk/TestAsk.rk"
+const file_path = "res://test/TestParser/TestAsk/TestAsk.rk"
 
-var file_base_name = file_name.get_file().get_basename()
+var file_base_name = get_file_base_name(file_path)
 
 func test_ask():
-	watch_signals(Rakugo)
+	watch_rakugo_signals()
+
+	yield(wait_parse_and_execute_script(file_path), "completed")
 	
-	Rakugo.parse_and_execute_script(file_name)
+	yield(wait_ask({}, "Are you human ?", "Yes"), "completed")
 	
-	yield(yield_to(Rakugo, "ask", 0.2), YIELD)
+	assert_ask_return("answer", "No")
 	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"ask",
-		[{}, "Are you human ?", "Yes"])
-		
-	Rakugo.ask_return("No")
-	
-	assert_eq("No", Rakugo.get_variable("answer"))
-	
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
-	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"execute_script_finished",
-		[file_base_name])
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestCharacter/TestCharacter.gd
+++ b/Test/TestParser/TestCharacter/TestCharacter.gd
@@ -1,19 +1,17 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://Test/TestParser/TestCharacter/TestCharacter.rk"
+const file_path = "res://Test/TestParser/TestCharacter/TestCharacter.rk"
+
+var file_base_name = get_file_base_name(file_path)
 
 func test_character():
-	Rakugo.parse_and_execute_script(file_name)
+	watch_rakugo_signals()
+
+	yield(wait_parse_and_execute_script(file_path), "completed")
+
+	yield(wait_execute_script_finished(file_base_name), "completed")
 	
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
-	
-	var sylvie = Rakugo.get_character("Sy")
-	
-	assert_ne(sylvie, {})
-	assert_eq(sylvie.get("name"), "Sylvie")
-	
-	var godot = Rakugo.get_character("Gd")
-	
-	assert_ne(godot, {})
-	assert_eq(godot.get("name"), "Godot")
+	assert_character_name_eq("Sy", "Sylvie")
+
+	assert_character_name_eq("Gd", "Godot")
 	

--- a/Test/TestParser/TestFinish/TestFinish.gd
+++ b/Test/TestParser/TestFinish/TestFinish.gd
@@ -1,18 +1,14 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
 const file_path = "res://Test/TestParser/TestFinish/TestFinish.rk"
 
-var file_name := ""
-func _on_execute_script_finished(file_base_name:String):
-	file_name = file_base_name
+var file_base_name = get_file_base_name(file_path)
 
 func test_finish():
-	Rakugo.connect("execute_script_finished", self, "_on_execute_script_finished")
-	
-	Rakugo.parse_and_execute_script(file_path)
-	
-	Rakugo.do_step()
+	watch_rakugo_signals()
 
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
-	
-	assert_eq(file_name, "TestFinish")
+	yield(wait_parse_and_execute_script(file_path), "completed")
+
+	assert_do_step()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestJumpIf/TestJumpIf.gd
+++ b/Test/TestParser/TestJumpIf/TestJumpIf.gd
@@ -1,29 +1,24 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://Test/TestParser/TestJumpIf/TestJumpIf.rk"
+const file_path = "res://Test/TestParser/TestJumpIf/TestJumpIf.rk"
 
-func before_all():
-	Rakugo.connect("say", self, "_on_say")
-	
-	Rakugo.parse_and_execute_script(file_name)
-
-var say_char:Dictionary
-var say_text:String
-func _on_say(character:Dictionary, text:String):
-	say_char = character
-	say_text = text
+var file_base_name = get_file_base_name(file_path)
 
 func test_jump_if():
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	watch_rakugo_signals()
+
+	yield(wait_parse_and_execute_script(file_path), "completed")
+
+	yield(wait_character_variable_changed("test_ch", "ax", TYPE_INT, 2), "completed")
+
+	yield(wait_variable_changed("ax", TYPE_INT, 2), "completed")
+
+	yield(wait_say({}, "no jump"), "completed")
 	
-	assert_true(say_char.empty())
-	assert_eq(say_text, "no jump")
+	assert_do_step()
 	
-	Rakugo.do_step()
-	
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
-	
-	assert_true(say_char.empty())
-	assert_eq(say_text, "jump")
-	
-	Rakugo.do_step()
+	yield(wait_say({}, "jump"), "completed")
+
+	assert_do_step()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestMenu/TestMenu.gd
+++ b/Test/TestParser/TestMenu/TestMenu.gd
@@ -1,35 +1,20 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://test/TestParser/TestMenu/TestMenu.rk"
+const file_path = "res://test/TestParser/TestMenu/TestMenu.rk"
 
-var file_base_name = file_name.get_file().get_basename()
+var file_base_name = get_file_base_name(file_path)
 
 func test_menu():
-	watch_signals(Rakugo)
+	watch_rakugo_signals()
 	
-	Rakugo.parse_and_execute_script(file_name)
+	yield(wait_parse_and_execute_script(file_path), "completed")
 	
-	yield(yield_to(Rakugo, "menu", 0.2), YIELD)
-	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"menu",
-		[PoolStringArray(["Loop", "End"])])
+	yield(wait_menu(["Loop", "End"]), "completed")
 
-	Rakugo.menu_return(0)
+	assert_menu_return(0);
 	
-	yield(yield_to(Rakugo, "menu", 0.2), YIELD)
-	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"menu",
-		[PoolStringArray(["Loop", "End"])])
+	yield(wait_menu(["Loop", "End"]), "completed")
 		
-	Rakugo.menu_return(1)
+	assert_menu_return(1);
 
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
-
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"execute_script_finished",
-		[file_base_name])
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestParseAndExecute/TestParseAndExecute.gd
+++ b/Test/TestParser/TestParseAndExecute/TestParseAndExecute.gd
@@ -1,43 +1,34 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_names = [
+const file_paths = [
 	"res://Test/TestParser/TestParseAndExecute/TestParseAndExecute_0.rk",
 	"res://Test/TestParser/TestParseAndExecute/TestParseAndExecute_1.rk"
 ]
 	
 var file_base_names = [
-	file_names[0].get_file().get_basename(),
-	file_names[1].get_file().get_basename()
+	get_file_base_name(file_paths[0]),
+	get_file_base_name(file_paths[1])
 ]
 
 var test_params = [[false, 0], [false, 1], [true, 0], [true, 1]]
 func test_parse_and_execute(params=use_parameters(test_params)):
 	watch_signals(Rakugo)
+
+	var index = params[1]
+
+	var file_path = file_paths[index]
+
+	var file_base_name = file_base_names[index]
 	
 	if params[0]:
-		Rakugo.execute_script(file_base_names[params[1]])
+		Rakugo.execute_script(file_base_name)
 	else:
-		Rakugo.parse_and_execute_script(file_names[params[1]])
+		Rakugo.parse_and_execute_script(file_path)
 	
-	yield(yield_to(Rakugo, "execute_script_start", 0.2), YIELD)
-	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"execute_script_start",
-		[file_base_names[params[1]]])
+	yield(wait_execute_script_start(file_base_name), "completed")
 
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	yield(wait_say({}, "Hello, world " + str(index) + " !"), "completed")
 
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"say",
-		[{}, "Hello, world " + str(params[1]) + " !"])
-		
-	Rakugo.do_step()
-		
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
+	assert_do_step()
 	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"execute_script_finished",
-		[file_base_names[params[1]]])
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestSay/TestSay.gd
+++ b/Test/TestParser/TestSay/TestSay.gd
@@ -1,63 +1,28 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://Test/TestParser/TestSay/TestSay.rk"
+const file_path = "res://Test/TestParser/TestSay/TestSay.rk"
 
-var file_base_name = file_name.get_file().get_basename()
+var file_base_name = get_file_base_name(file_path)
 
 func test_say():
-	watch_signals(Rakugo)
+	watch_rakugo_signals()
 
-	Rakugo.parse_and_execute_script(file_name)
+	yield(wait_parse_and_execute_script(file_path), "completed")
 
-	yield(yield_to(Rakugo, "execute_script_start", 0.2), YIELD)
+	yield(wait_say({}, "Hello, world !"), "completed")
 
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
-
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"say",
-		[{}, "Hello, world !"])
-
-	assert_true(Rakugo.waiting_step)
+	assert_do_step()
 	
-	Rakugo.do_step()
-	
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	yield(wait_say({"name": "Sylvie"}, "Hello !"), "completed")
 
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"say",
-		[{"name": "Sylvie"}, "Hello !"])
+	assert_do_step()
 
-	assert_true(Rakugo.waiting_step)
+	yield(wait_say({}, "My name is Sylvie"), "completed")
 	
-	Rakugo.do_step()
+	assert_do_step()
 	
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	yield(wait_say({}, "I am 18"), "completed")
 	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"say",
-		[{}, "My name is Sylvie"])
-	
-	assert_true(Rakugo.waiting_step)
+	assert_do_step()
 
-	Rakugo.do_step()
-	
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
-	
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"say",
-		[{}, "I am 18"])
-	
-	assert_true(Rakugo.waiting_step)
-
-	Rakugo.do_step()
-
-	yield(yield_to(Rakugo, "execute_script_finished", 0.2), YIELD)
-
-	assert_signal_emitted_with_parameters(
-		Rakugo,
-		"execute_script_finished",
-		[file_base_name])
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestStartFromLabel/TestStartFromLabel.gd
+++ b/Test/TestParser/TestStartFromLabel/TestStartFromLabel.gd
@@ -1,18 +1,16 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
 const file_path = "res://Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk"
 
-var say_char:Dictionary
-var say_text:String
-func _on_say(character:Dictionary, text:String):
-	say_char = character
-	say_text = text
+var file_base_name = get_file_base_name(file_path)
 
 func test_start_from_label():
-	Rakugo.connect("say", self, "_on_say")
-	
 	Rakugo.parse_and_execute_script(file_path, "pictures")
-	
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
-	
-	assert_eq(say_text, "Pictures of places that I have visited.")
+
+	yield(wait_execute_script_start(file_path), "completed")
+
+	yield(wait_say({}, "Pictures of places that I have visited."), "completed")
+
+	assert_do_step()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk
+++ b/Test/TestParser/TestStartFromLabel/TestStartFromLabel.rk
@@ -1,5 +1,11 @@
 door:
 "Where did I put the key?"
+exit
 
 pictures:
 "Pictures of places that I have visited."
+exit
+
+plants:
+"They need water."
+exit

--- a/Test/TestParser/TestVariables/TestVariables.gd
+++ b/Test/TestParser/TestVariables/TestVariables.gd
@@ -1,44 +1,28 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
 
-const file_name = "res://Test/TestParser/TestVariables/TestVariables.rk"
+const file_path = "res://Test/TestParser/TestVariables/TestVariables.rk"
 
-func before_all():
-	Rakugo.parse_and_execute_script(file_name)
+var file_base_name = get_file_base_name(file_path)
 
 func test_variables():
-	yield(yield_to(Rakugo, "say", 0.2), YIELD)
+	watch_rakugo_signals()
 
-	var a = Rakugo.get_variable("aaa")
-	
-	assert_eq(typeof(a), TYPE_INT)
-	assert_eq(a, 1)
+	yield(wait_parse_and_execute_script(file_path), "completed")
 
-	var b = Rakugo.get_variable("bbb")
+	yield(wait_execute_script_finished(file_base_name), "completed")
 
-	assert_eq(typeof(b), TYPE_REAL)
-	assert_eq(b, 2.5)
+	assert_variable("aaa", TYPE_INT, 1)
 
-	var c = Rakugo.get_variable("ccc")
+	assert_variable("bbb", TYPE_REAL, 2.5)
 
-	assert_eq(typeof(c), TYPE_STRING)
-	assert_eq(c, "Hello, world !")
+	assert_variable("ccc", TYPE_STRING, "Hello, world !")
 
-	var d = Rakugo.get_variable("ddd")
+	assert_variable("ddd", TYPE_INT, Rakugo.get_variable("aaa"))
+
+	assert_variable("Sy.name", TYPE_STRING, "Sylvie")
 	
-	assert_eq(d, a)
+	assert_variable("Sy.life", TYPE_INT, 5)
 	
-	var syname = Rakugo.get_variable("Sy.name")
-	
-	assert_eq(typeof(syname), TYPE_STRING)
-	assert_eq(syname, "Sylvie")
-	
-	var sylife = Rakugo.get_variable("Sy.life")
-	
-	assert_eq(typeof(sylife), TYPE_INT)
-	assert_eq(sylife, 5)
-	
-	var e = Rakugo.get_variable("eee")
-	
-	assert_eq(e, sylife)
+	assert_variable("eee", TYPE_INT, Rakugo.get_variable("Sy.life"))
 
 	assert_eq(Rakugo.get_variable("fff"), null)

--- a/Test/TestParser/TestVariables/TestVariables.rk
+++ b/Test/TestParser/TestVariables/TestVariables.rk
@@ -5,4 +5,3 @@ ddd = aaa
 character Sy "Sylvie"
 Sy.life = 5
 eee = Sy.life
-"Test"


### PR DESCRIPTION
fix #174
fix #166 

- Add RakugoTest Class
- Update all parser tests
- TestStartFromLabel failed, it is normal. Test is right, dev not.

Why I do `extends "res://Test/RakugoTest.gd"` instead of add `class_name RakugoTest` in `RakugoTest.gd`, and do `extends RakugoTest` ?

Because, if I do this, it is update project.godot. It contains all class_name (you can see it for gut). On a big project, with more peoples, it can generate conflicts easily. And it is not cool to resolve conflict by hand in project.godot...

( I like the fact, I added less lines than I removed )