### PR TITLE
Fix #93 : Now variable name can be one letter long

### DIFF
--- a/Test/TestParser/TestVariables/TestVariables.gd
+++ b/Test/TestParser/TestVariables/TestVariables.gd
@@ -11,18 +11,18 @@ func test_variables():
 
 	yield(wait_execute_script_finished(file_base_name), "completed")
 
-	assert_variable("aaa", TYPE_INT, 1)
+	assert_variable("a", TYPE_INT, 1)
 
-	assert_variable("bbb", TYPE_REAL, 2.5)
+	assert_variable("b", TYPE_REAL, 2.5)
 
-	assert_variable("ccc", TYPE_STRING, "Hello, world !")
+	assert_variable("c", TYPE_STRING, "Hello, world !")
 
-	assert_variable("ddd", TYPE_INT, Rakugo.get_variable("aaa"))
+	assert_variable("d", TYPE_INT, Rakugo.get_variable("a"))
 
 	assert_variable("Sy.name", TYPE_STRING, "Sylvie")
 	
 	assert_variable("Sy.life", TYPE_INT, 5)
 	
-	assert_variable("eee", TYPE_INT, Rakugo.get_variable("Sy.life"))
+	assert_variable("e", TYPE_INT, Rakugo.get_variable("Sy.life"))
 
-	assert_eq(Rakugo.get_variable("fff"), null)
+	assert_eq(Rakugo.get_variable("f"), null)

--- a/Test/TestParser/TestVariables/TestVariables.rk
+++ b/Test/TestParser/TestVariables/TestVariables.rk
@@ -1,7 +1,7 @@
-aaa = 1
-bbb = 2.5
-ccc = "Hello, world !"
-ddd = aaa
+a = 1
+b = 2.5
+c = "Hello, world !"
+d = a
 character Sy "Sylvie"
 Sy.life = 5
-eee = Sy.life
+e = Sy.life

--- a/addons/Rakugo/lib/systems/Executer.gd
+++ b/addons/Rakugo/lib/systems/Executer.gd
@@ -11,7 +11,7 @@ var current_semaphore:Semaphore
 var threads:Dictionary
 
 var regex := {
-	NAME = "[a-zA-Z_][a-zA-Z_0-9]+",
+	NAME = "[a-zA-Z][a-zA-Z_0-9]*",
 	VARIABLE = "((?<char_tag>{NAME})\\.)?(?<var_name>{NAME})",
 	VARIABLE_IN_STR = "\\<(?<variable>{VARIABLE})\\>"
 }

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -39,7 +39,7 @@ var Tokens := {
 }
 
 var Regex := {
-	NAME = "[a-zA-Z_][a-zA-Z_0-9]+",
+	NAME = "[a-zA-Z][a-zA-Z_0-9]*",
 	NUMERIC = "-?[1-9][0-9.]*",
 	STRING = "\".*\"",
 	VARIABLE = "((?<char_tag>{NAME})\\.)?(?<var_name>{NAME})",


### PR DESCRIPTION
fix #93 

I update NAME regex. It used for both variable and character_tag.

So char_tag can't start by a '_'.