### PR TITLE
Fix #156 : Executer, handle errors

### DIFF
--- a/Test/RakugoTest.gd
+++ b/Test/RakugoTest.gd
@@ -32,8 +32,8 @@ func assert_ask_return(var_name:String, value):
 	
 	assert_eq(value, Rakugo.get_variable(var_name))
 
-func wait_execute_script_finished(file_base_name:String):
-	return wait_signal("execute_script_finished", [file_base_name])
+func wait_execute_script_finished(file_base_name:String, error_str:String = ""):
+	return wait_signal("execute_script_finished", [file_base_name, error_str])
 
 func assert_character_name_eq(char_tag:String, value:String):
 	var character = Rakugo.get_character(char_tag)

--- a/addons/Rakugo/Rakugo.gd
+++ b/addons/Rakugo/Rakugo.gd
@@ -47,7 +47,7 @@ signal ask(character, question, default_answer)
 signal menu(choices)
 signal parser_unhandled_regex(key, result)
 signal execute_script_start(file_name)
-signal execute_script_finished(file_name)
+signal execute_script_finished(file_name, error_str)
 signal variable_changed(var_name, value)
 signal character_variable_changed(character_tag, var_name, value)
 
@@ -188,8 +188,8 @@ func parse_and_execute_script(file_name: String, label_name: String = "") -> int
 func send_execute_script_start(file_base_name: String):
 	emit_signal("execute_script_start", file_base_name)
 
-func send_execute_script_finished(file_base_name: String):
-	emit_signal("execute_script_finished", file_base_name)
+func send_execute_script_finished(file_base_name: String, error_str:String):
+	emit_signal("execute_script_finished", file_base_name, error_str)
 
 
 func _exit_tree() -> void:


### PR DESCRIPTION
fix #156 

Major change:
Add parameter error_str in signal execute_script_finished. If is empty no error, else contain error string. It can be used to show it. Already used with push_error, so do not do it again !