### PR TITLE
Fix #134 : Add Rakugo.stop_last_script

### DIFF
--- a/.gut_editor_config.json
+++ b/.gut_editor_config.json
@@ -3,6 +3,7 @@
  "config_file": "res://.gutconfig.json",
  "dirs": [
   "res://Test/TestParser",
+  "res://Test/TestExecuter",
   "res://Test/TestRakugo"
  ],
  "disable_colors": false,

--- a/.gutconfig.json
+++ b/.gutconfig.json
@@ -1,0 +1,14 @@
+{
+    "dirs": [
+        "res://Test/TestParser",
+        "res://Test/TestExecuter",
+        "res://Test/TestRakugo"
+    ],
+    "include_subdirs":true,
+    "ignore_pause":true,
+    "log_level":2,
+    "should_exit":false,
+    "should_maximize":true,
+    "prefix": "Test",
+    "suffix": ".gd"
+}

--- a/Test/TestExecuter/TestStop/TestStop.gd
+++ b/Test/TestExecuter/TestStop/TestStop.gd
@@ -1,0 +1,16 @@
+extends "res://Test/RakugoTest.gd"
+
+const file_path = "res://Test/TestExecuter/TestStop/TestStop.rk"
+
+var file_base_name = get_file_base_name(file_path)
+
+func test_stop():
+	watch_rakugo_signals()
+	
+	yield(wait_parse_and_execute_script(file_path), "completed")
+
+	yield(wait_say({}, "You can see this message"), "completed")
+
+	Rakugo.stop_last_script()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")

--- a/Test/TestExecuter/TestStop/TestStop.rk
+++ b/Test/TestExecuter/TestStop/TestStop.rk
@@ -1,0 +1,2 @@
+"You can see this message"
+"If you see this message, the test fail"

--- a/Test/TestExecuter/TestStop/TestStop.tscn
+++ b/Test/TestExecuter/TestStop/TestStop.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://Test/TestExecuter/TestStop/TestStop.gd" type="Script" id=1]
+
+[node name="TestStop" type="Node"]
+script = ExtResource( 1 )

--- a/addons/Rakugo/Rakugo.gd
+++ b/addons/Rakugo/Rakugo.gd
@@ -175,10 +175,12 @@ func load_game(save_name := "quick"):
 func parse_script(file_name: String) -> int:
 	return parser.parse_script(file_name)
 
-
+# Executer
 func execute_script(script_name: String, label_name: String = "") -> int:
 	return executer.execute_script(script_name, label_name)
 
+func stop_last_script():
+	executer.stop_current_thread()
 
 func parse_and_execute_script(file_name: String, label_name: String = "") -> int:
 	if parser.parse_script(file_name) == OK:
@@ -193,7 +195,7 @@ func send_execute_script_finished(file_base_name: String, error_str:String):
 
 
 func _exit_tree() -> void:
-	executer.close()
+	executer.stop_current_thread()
 
 
 # Todo Handle Error


### PR DESCRIPTION
fix #134 

## Major:
Add `Rakugo.stop_last_script` and not `Rakugo.stop_script()` or `Rakugo.stop_script(script_name)`. 
The last one need refactor before implement it. The second one is not enough explicit I think. 
So I add first one because it is in philosophy we have : one thread at a time. 
We need refactor to handles multiples thread at same time. Work for 1.3.

## In changelog:
Add folder *TestExecuter* and *TestStop*

## Bug:
Fix, reset both `current_thread`, ` current_semaphore` to `null`, 
plus remove `thread` from `threads` when his execution finish