### PR TITLE
Fix #88 : Save load thread

### DIFF
--- a/Test/RakugoTest.gd
+++ b/Test/RakugoTest.gd
@@ -57,7 +57,7 @@ func assert_variable(var_name:String, var_type, value):
 func wait_character_variable_changed(char_tag:String, var_name:String, var_type, value):
 	yield(wait_signal("character_variable_changed", [char_tag, var_name, value]), "completed")
 
-	assert_variable(var_name, var_type, value)
+	assert_variable(char_tag+"."+var_name, var_type, value)
 
 func wait_variable_changed(var_name:String, var_type, value):
 	yield(wait_signal("variable_changed", [var_name, value]), "completed")

--- a/Test/TestRakugo/TestSaveLoad/TestSaveLoad.gd
+++ b/Test/TestRakugo/TestSaveLoad/TestSaveLoad.gd
@@ -1,7 +1,11 @@
-extends GutTest
+extends "res://Test/RakugoTest.gd"
+
+const file_path = "res://Test/TestRakugo/TestSaveLoad/TestSaveLoad.rk"
+
+var file_base_name = get_file_base_name(file_path)
 
 func before_all():
-	var save_folder = "user://saves/quick"
+	var save_folder = ProjectSettings.get_setting("addons/rakugo/save_folder")
 	
 	var directory = Directory.new()
 	
@@ -14,15 +18,43 @@ func before_all():
 		directory.remove(save_folder)
 
 func test_save_load():
+	watch_rakugo_signals()
+
 	Rakugo.set_variable("life", 5)
+
+	wait_variable_changed("life", TYPE_INT, 5)
 	
 	Rakugo.define_character("Sy", "Sylvie")
 	
 	Rakugo.set_variable("Sy.friendship", 3)
+
+	wait_character_variable_changed("Sy", "friendship", TYPE_INT, 3)
+
+	yield(wait_parse_and_execute_script(file_path), "completed")
+
+	yield(wait_say({}, "Hello, world !"), "completed")
+
+	assert_do_step()
+
+	yield(wait_say({}, "Save from here"), "completed")
 	
 	Rakugo.save_game()
+
+	Rakugo.stop_last_script()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")
 	
 	Rakugo.load_game()
+
+	Rakugo.resume_loaded_script()
+
+	yield(wait_execute_script_start(file_base_name), "completed")
+
+	yield(wait_say({}, "Save from here"), "completed")
+
+	Rakugo.stop_last_script()
+
+	yield(wait_execute_script_finished(file_base_name), "completed")
 	
 	assert_eq(Rakugo.get_variable("life"), 5)
 

--- a/Test/TestRakugo/TestSaveLoad/TestSaveLoad.rk
+++ b/Test/TestRakugo/TestSaveLoad/TestSaveLoad.rk
@@ -1,0 +1,2 @@
+"Hello, world !"
+"Save from here"

--- a/addons/Rakugo/Rakugo.gd
+++ b/addons/Rakugo/Rakugo.gd
@@ -36,6 +36,9 @@ var waiting_ask_return := false setget , is_waiting_ask_return
 
 var waiting_menu_return := false setget , is_waiting_menu_return
 
+# when you load game to run last script
+var last_thread_datas:Dictionary
+
 onready var store_manager := StoreManager.new()
 onready var parser := Parser.new(store_manager)
 onready var executer := Executer.new(store_manager)
@@ -178,12 +181,16 @@ func _ready():
 
 
 func save_game(save_name: String = "quick"):
-	store_manager.save_game(save_name)
+	store_manager.save_game(executer.get_current_thread_datas(), save_name)
 
 
 func load_game(save_name := "quick"):
-	store_manager.load_game(save_name)
+	last_thread_datas = store_manager.load_game(save_name)
+	parse_script(last_thread_datas["path"])
 
+func resume_loaded_script():
+	if !last_thread_datas.empty():
+		executer.execute_script(last_thread_datas["file_base_name"], "", last_thread_datas["last_index"])
 
 # Parser
 func parse_script(file_name: String) -> int:

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -258,6 +258,6 @@ func parse_script(path:String) -> int:
 		if state == State.Menu and i == lines.size() - 1 and !menu_choices.empty():
 			parse_array.push_back(["MENU", current_menu_result, menu_choices])
 	
-	store_manager.parsed_scripts[path.get_file().get_basename()] = {"parse_array":parse_array, "labels":labels}
+	store_manager.parsed_scripts[path.get_file().get_basename()] = {"path": path, "parse_array":parse_array, "labels":labels}
 	
 	return OK

--- a/addons/Rakugo/lib/systems/StoreManager.gd
+++ b/addons/Rakugo/lib/systems/StoreManager.gd
@@ -70,8 +70,7 @@ func save_json(path: String, data: Dictionary) -> int:
 	push_error("can't open file: " + path)
 	return ERR_FILE_CANT_OPEN
 
-
-func save_game(save_name: String = "quick") -> int:
+func save_game(thread_datas:Dictionary, save_name: String = "quick") -> int:
 	var save_folder = save_folder_path + "/" + save_name
 
 	var directory = Directory.new()
@@ -81,10 +80,17 @@ func save_game(save_name: String = "quick") -> int:
 			push_error("can't create dir: " + save_folder)
 			return FAILED
 
-	return save_json(save_folder + "/save.json", {"variables": variables, "characters": characters})
+	var sava_datas = {"variables": variables, "characters": characters}
+
+	if !thread_datas.empty():
+		thread_datas["path"] = parsed_scripts[thread_datas["file_base_name"]]["path"]
+
+		sava_datas["thread_datas"] = thread_datas
+
+	return save_json(save_folder + "/save.json", sava_datas)
 
 
-func load_game(save_name: String = "quick") -> int:
+func load_game(save_name: String = "quick") -> Dictionary:
 	var save_folder = save_folder_path + "/" + save_name
 
 	var directory = Directory.new()
@@ -92,10 +98,11 @@ func load_game(save_name: String = "quick") -> int:
 	if directory.dir_exists(save_folder):
 		var dico = load_json(save_folder + "/save.json")
 
-		variables = dico["variables"]
-		characters = dico["characters"]
+		if !dico.empty():
+			variables = dico["variables"]
+			characters = dico["characters"]
 
-		return OK
+			return dico.get("thread_datas", {})
 
 	push_error("save folder does not exist at path: " + save_folder)
-	return FAILED
+	return {}


### PR DESCRIPTION
fix #88 

## Major change
Rakugo.save_game(), now save name of current executed script, plus last line read. So with
Rakugo.load_game(), now parse last executed script.
Rakugo.resume_loaded_script(), run last executed script.

We split load in 2 funcs. So you can call Rakugo.load_game(), to loads variables as usual and load your scenes with them. And after everything is ready, call Rakugo.execute_last_script().

## Bug
Fix wait_character_variable_changed, now it call assert_variable correctly : char_tag+"."+var_name