### PR TITLE
Fix #152 : Autoload Rakugo.gd

### DIFF
--- a/addons/Rakugo/lib/systems/Executer.gd
+++ b/addons/Rakugo/lib/systems/Executer.gd
@@ -1,4 +1,4 @@
-extends Object
+extends Reference
 
 const jump_error = "Executer::do_execute_jump, can not jump to unknow label : "
 

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -1,4 +1,4 @@
-extends Object
+extends Reference
 
 # this code base on code from:
 # https://github.com/nathanhoad/godot_dialogue_manager 

--- a/addons/Rakugo/lib/systems/StoreManager.gd
+++ b/addons/Rakugo/lib/systems/StoreManager.gd
@@ -1,4 +1,4 @@
-extends Node
+extends Reference
 
 var save_folder_path:String
 

--- a/addons/Rakugo/plugin.gd
+++ b/addons/Rakugo/plugin.gd
@@ -4,7 +4,7 @@ extends EditorPlugin
 
 func _enter_tree():
 	# Initialization of the plugin goes here
-	add_autoload_singleton("Rakugo", "res://addons/Rakugo/Rakugo.tscn")
+	add_autoload_singleton("Rakugo", "res://addons/Rakugo/Rakugo.gd")
 
 	#TODO look if setting are saved and load them
 

--- a/project.godot
+++ b/project.godot
@@ -32,17 +32,16 @@ _global_script_class_icons={
 
 [addons]
 
-rakugo/spaghetti="bolognaise"
 rakugo/force_reload=false
 rakugo/auto_mode_delay=3
 rakugo/skip_delay=0.5
 rakugo/rollback_steps=10
+rakugo/test_mode=false
 rakugo/game_version="1.0.0"
 rakugo/history_length=30
 rakugo/narrator/name="narrator"
 rakugo/debug=false
 rakugo/save_folder="user://saves"
-rakugo/test_mode=false
 
 [application]
 
@@ -52,7 +51,7 @@ config/icon="res://icon.png"
 
 [autoload]
 
-Rakugo="*res://addons/Rakugo/Rakugo.tscn"
+Rakugo="*res://addons/Rakugo/Rakugo.gd"
 
 [debug]
 


### PR DESCRIPTION
fix #152 

## Major
autoload Rakugo.gd instead of Rakugo.tscn
remove Rakugo.tscn

## In Changelog
fix memory leak (extends reference instead of object)
remove unused sphagetti