### PR TITLE
fix #245 ask like doc

### DIFF
--- a/Test/TestExecuter/TestAsk/TestAsk.gd
+++ b/Test/TestExecuter/TestAsk/TestAsk.gd
@@ -1,0 +1,16 @@
+extends "res://Test/RakugoTest.gd"
+
+const file_path = "res://Test/TestExecuter/TestAsk/TestAsk.rk"
+
+var file_base_name = get_file_base_name(file_path)
+
+func test_ask():
+	watch_rakugo_signals()
+
+	await wait_parse_and_execute_script(file_path)
+	
+	await wait_ask({}, "Are you human ?", "Yes")
+	
+	assert_ask_return("answer", "No")
+	
+	await wait_execute_script_finished(file_base_name)

--- a/Test/TestExecuter/TestAsk/TestAsk.rk
+++ b/Test/TestExecuter/TestAsk/TestAsk.rk
@@ -1,0 +1,1 @@
+answer = ? "Are you human ?" "Yes"

--- a/Test/TestExecuter/TestAsk/TestAsk.tscn
+++ b/Test/TestExecuter/TestAsk/TestAsk.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://c65gxwwshluof"]
+
+[ext_resource type="Script" path="res://Test/TestParser/TestAsk/TestAsk.gd" id="1"]
+
+[node name="TestAsk" type="Node"]
+script = ExtResource("1")

--- a/Test/TestParser/TestAsk/TestAsk.gd
+++ b/Test/TestParser/TestAsk/TestAsk.gd
@@ -1,16 +1,101 @@
-extends "res://Test/RakugoTest.gd"
+extends GutTest
 
-const file_path = "res://Test/TestParser/TestAsk/TestAsk.rk"
+const Parser = preload("res://addons/Rakugo/lib/systems/Parser.gd")
 
-var file_base_name = get_file_base_name(file_path)
+@onready var parser := Parser.new()
 
-func test_ask():
-	watch_rakugo_signals()
+var test_ask_params = [
+	["answer=?\"Hello ?\""],
+	["answer = ? \"Hello ?\""]
+]
 
-	await wait_parse_and_execute_script(file_path)
-	
-	await wait_ask({}, "Are you human ?", "Yes")
-	
-	assert_ask_return("answer", "No")
-	
-	await wait_execute_script_finished(file_base_name)
+func test_ask(params=use_parameters(test_ask_params)):
+	var parsed_script = parser.parse_script(params)
+
+	assert_false(parsed_script.is_empty())
+
+	var parsed_array = parsed_script["parse_array"]
+
+	assert_false(parsed_array.is_empty())
+
+	assert_true(parsed_array[0][0] == "ASK")
+
+	var result = parsed_array[0][1]
+
+	assert_eq(result.get_string("variable"), "answer")
+
+	assert_eq(result.get_string("question"), "\"Hello ?\"")
+
+var test_ask_default_answer_params = [
+	["answer=?\"Hello ?\" \"Bob\""],
+	["answer = ? \"Hello ?\" \"Bob\""]
+]
+
+func test_ask_default_answer(params=use_parameters(test_ask_default_answer_params)):
+	var parsed_script = parser.parse_script(params)
+
+	assert_false(parsed_script.is_empty())
+
+	var parsed_array = parsed_script["parse_array"]
+
+	assert_false(parsed_array.is_empty())
+
+	assert_true(parsed_array[0][0] == "ASK")
+
+	var result = parsed_array[0][1]
+
+	assert_eq(result.get_string("variable"), "answer")
+
+	assert_eq(result.get_string("question"), "\"Hello ?\"")
+
+	assert_eq(result.get_string("default_answer"), "\"Bob\"")
+
+var test_ask_tag_params = [
+	["answer=?gd \"Hello ?\""],
+	["answer = ? gd \"Hello ?\""]
+]
+
+func test_ask_tag(params=use_parameters(test_ask_tag_params)):
+	var parsed_script = parser.parse_script(params)
+
+	assert_false(parsed_script.is_empty())
+
+	var parsed_array = parsed_script["parse_array"]
+
+	assert_false(parsed_array.is_empty())
+
+	assert_true(parsed_array[0][0] == "ASK")
+
+	var result = parsed_array[0][1]
+
+	assert_eq(result.get_string("variable"), "answer")
+
+	assert_eq(result.get_string("character_tag"), "gd")
+
+	assert_eq(result.get_string("question"), "\"Hello ?\"")
+
+var test_ask_all_params = [
+	["answer=?gd \"Hello ?\" \"Bob\""],
+	["answer = ? gd \"Hello ?\" \"Bob\""]
+]
+
+func test_ask_all(params=use_parameters(test_ask_all_params)):
+	var parsed_script = parser.parse_script(params)
+
+	assert_false(parsed_script.is_empty())
+
+	var parsed_array = parsed_script["parse_array"]
+
+	assert_false(parsed_array.is_empty())
+
+	assert_true(parsed_array[0][0] == "ASK")
+
+	var result = parsed_array[0][1]
+
+	assert_eq(result.get_string("variable"), "answer")
+
+	assert_eq(result.get_string("character_tag"), "gd")
+
+	assert_eq(result.get_string("question"), "\"Hello ?\"")
+
+	assert_eq(result.get_string("default_answer"), "\"Bob\"")

--- a/Test/TestParser/TestAsk/TestAsk.rk
+++ b/Test/TestParser/TestAsk/TestAsk.rk
@@ -1,1 +1,0 @@
-answer = "Are you human ?" ? "Yes"

--- a/addons/Rakugo/lib/systems/Parser.gd
+++ b/addons/Rakugo/lib/systems/Parser.gd
@@ -39,7 +39,7 @@ var Tokens := {
 var Regex := {
 	NAME = "[a-zA-Z][a-zA-Z_0-9]*",
 	NUMERIC = "-?[0-9]\\.?[0-9]*",
-	STRING = "\".*\"",
+	STRING = "\"[^\"]*\"",
 	VARIABLE = "((?<char_tag>{NAME})\\.)?(?<var_name>{NAME})",
 #	MULTILINE_STRING = "\"\"\"(?<string>.*)\"\"\"",
 }
@@ -59,7 +59,7 @@ var parser_regex :={
 	# character_tag? "say"
 	SAY = "^((?<character_tag>{NAME}) )?(?<text>{STRING})$",
 	# var_name = character_tag? "please enter text" 
-	ASK = "^(?<variable>{VARIABLE}) = ((?<character_tag>{NAME}) )?(?<question>{STRING}) \\? (?<default_answer>{STRING})$",
+	ASK = "^(?<variable>{VARIABLE})\\s*=\\s*\\?\\s*((?<character_tag>{NAME}) )?(?<question>{STRING})( (?<default_answer>{STRING}))?$",
 	# "like regex" (> label_name)?
 	CHOICE = "^(?<text>{STRING})( > (?<label>{NAME}))?$",
 	# jump label
@@ -143,6 +143,8 @@ func parse_script(lines:PackedStringArray) -> Dictionary:
 	
 	for i in lines.size():
 		var line = lines[i]
+		
+		prints("Parser", line)
 
 		line = line.strip_edges()
 


### PR DESCRIPTION
fix #245 

Now ask is same as the one in the documention

Plus you can respect or not the number of space between the '=' and '?'
`answer = ? "question"` is correct
`answer=?"question"` is also correct

But you should respect spaces between tag, question, and default answer
`answer=?tag "question" "default answer"` is correct
`answer=?tag"question""default answer"` is not